### PR TITLE
Fix UserSeeder

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -18,6 +18,7 @@ define('LARAVEL_START', microtime(true));
 
 if (file_exists($maintenance = __DIR__.'/../storage/framework/maintenance.php')) {
     require $maintenance;
+    //inclued maintenance if file exists
 }
 
 /*


### PR DESCRIPTION
Database\Seeders\UserSeeder::Database\Seeders\{closure}(): Argument #1 ($name) must be of type string, array given

Ref: https://github.com/spatie/spatie.be/commit/efab7d525f5ca8ce6c361c600ec589be625fea73#diff-fb4bcb1a99493df932c6a25f45dc0b1ef2e8e2f6fc1d21ac457bc0dc394dbb7a

Today I will spend my free time contributing to this repository. :)